### PR TITLE
fix(local_datacurso_ratings): align schema defaults with install.xml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+## 1.0.3
+
+**Released on:** 2026-04-29
+
+**Compatibility note:** This version is compatible **from Moodle 4.5 to Moodle 5.1**.
+
+## Fixed
+- **Database schema defaults aligned with install definition**
+  Added an upgrade step that removes legacy default values from `local_datacurso_ratings.courseid`, `local_datacurso_ratings.categoryid`, and `local_datacurso_ratings_feedback.type` so upgraded sites match `db/install.xml` and pass Moodle schema checks
+
+## Changed
+- **Version bump**
+  Internal version bumped to **2026042900** and release bumped to **1.0.3**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 ## Fixed
 - **Database schema defaults aligned with install definition**
   Added an upgrade step that removes legacy default values from `local_datacurso_ratings.courseid`, `local_datacurso_ratings.categoryid`, and `local_datacurso_ratings_feedback.type` so upgraded sites match `db/install.xml` and pass Moodle schema checks
+- **Indexed field default migration no longer fails**
+  The upgrade now temporarily drops and restores `courseid_idx` and `categoryid_idx` while updating defaults, preventing DDL dependency errors during plugin upgrade
 
 ## Changed
 - **Version bump**

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -113,5 +113,29 @@ function xmldb_local_datacurso_ratings_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026031701, 'local', 'datacurso_ratings');
     }
 
+    if ($oldversion < 2026042900) {
+        $table = new xmldb_table('local_datacurso_ratings');
+
+        // Remove legacy defaults introduced during upgrades to keep the schema
+        // aligned with install.xml definitions.
+        $field = new xmldb_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'cmid');
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+        }
+
+        $field = new xmldb_field('categoryid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'courseid');
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+        }
+
+        $table = new xmldb_table('local_datacurso_ratings_feedback');
+        $field = new xmldb_field('type', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, null, 'feedbacktext');
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2026042900, 'local', 'datacurso_ratings');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -118,14 +118,32 @@ function xmldb_local_datacurso_ratings_upgrade($oldversion) {
 
         // Remove legacy defaults introduced during upgrades to keep the schema
         // aligned with install.xml definitions.
+        $index = new xmldb_index('courseid_idx', XMLDB_INDEX_NOTUNIQUE, ['courseid']);
+        if ($dbman->index_exists($table, $index)) {
+            $dbman->drop_index($table, $index);
+        }
+
         $field = new xmldb_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'cmid');
         if ($dbman->field_exists($table, $field)) {
             $dbman->change_field_default($table, $field);
         }
 
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        $index = new xmldb_index('categoryid_idx', XMLDB_INDEX_NOTUNIQUE, ['categoryid']);
+        if ($dbman->index_exists($table, $index)) {
+            $dbman->drop_index($table, $index);
+        }
+
         $field = new xmldb_field('categoryid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'courseid');
         if ($dbman->field_exists($table, $field)) {
             $dbman->change_field_default($table, $field);
+        }
+
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
         }
 
         $table = new xmldb_table('local_datacurso_ratings_feedback');

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_datacurso_ratings';
-$plugin->version   = 2026031703;
+$plugin->version   = 2026042900;
 $plugin->requires = 2024100700;
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.0.2';
+$plugin->release   = '1.0.3';
 $plugin->supported = [405, 501];
 $plugin->dependencies = [
     'aiprovider_datacurso' => 2025100201,


### PR DESCRIPTION
### Context
Moodle database schema checks were reporting mismatches for `local_datacurso_ratings` on upgraded sites because some field defaults in the database did not match the plugin install definition.

### Description
- Added a new upgrade step to remove legacy defaults from `courseid` and `categoryid` in `local_datacurso_ratings`
- Extended the same schema alignment for `type` in `local_datacurso_ratings_feedback`
- Updated plugin version to `2026042900` and release to `1.0.3`
- Added `CHANGES.md` documenting this fix

### Steps to review
1. Upgrade the plugin from a version older than `2026042900`
2. Confirm the upgrade step executes successfully
3. Open Moodle performance overview and run database schema check
4. Verify the plugin tables no longer report default-value mismatches

### Verification
Schema-alignment upgrade logic was added for all affected fields and plugin metadata was updated consistently so the new migration runs on upgrade.

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the project license.